### PR TITLE
Adding support for authenticated calls to the mapquest api

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Dependencies
  */
@@ -15,22 +14,17 @@ var url = 'http://open.mapquestapi.com/geocoding/v1';
  * Geocode an address
  */
 
-module.exports.geocode = function(address, callback) {
-  get(url + '/address').query({ location: address, maxResults: 1 }).end(function(err, res) {
+module.exports.geocode = function(key, address, callback) {
+  if (key != undefined) {
+    u = url + '/address?key='+key;
+  } else {
+    u = url + '/address';
+  }  
+  get(u).query({location: address, maxResults: 1 }).end(function(err, res) {
     if (err) {
       callback(err);
     } else {
-      callback(null, res.body.results[0].locations[0]);
-    }
-  });
-};
-
-module.exports.geocodeAuthenticated = function(key, address, callback) {
-  get(url + '/address?key='+key).query({location: address, maxResults: 1 }).end(function(err, res) {
-    if (err) {
-      callback(err);
-    } else {
-      callback(null, res.body.results[0].locations[0]);
+      callback(null, res.body.results[0].locations);
     }
   });
 };
@@ -39,22 +33,17 @@ module.exports.geocodeAuthenticated = function(key, address, callback) {
  * Reverse geocode a lat, lon
  */
 
-module.exports.reverse = function(coordinates, callback) {
-  get(url + '/reverse').query({ location: coordinates.latitude + ',' + coordinates.longitude, maxResults: 1 }).end(function(err, res) {
+module.exports.reverse = function(key, coordinates, callback) {
+  if (key != undefined) {
+    u = url + '/reverse?key='+key;
+  } else {
+    u = url + '/reverse';
+  }
+  get(u).query({ location: coordinates.latitude + ',' + coordinates.longitude, maxResults: 1 }).end(function(err, res) {
     if (err) {
       callback(err);
     } else {
-      callback(null, res.body.results[0].locations[0]);
-    }
-  });
-};
-
-module.exports.reverseAuthenticated = function(key, coordinates, callback) {
-  get(url + '/reverse?key='+key).query({ location: coordinates.latitude + ',' + coordinates.longitude, maxResults: 1 }).end(function(err, res) {
-    if (err) {
-      callback(err);
-    } else {
-      callback(null, res.body.results[0].locations[0]);
+      callback(null, res.body.results[0].locations);
     }
   });
 };
@@ -63,26 +52,13 @@ module.exports.reverseAuthenticated = function(key, coordinates, callback) {
  * Batch geocode addresses
  */
 
-module.exports.batch = function(addresses, callback) {
-  var batch = get(url + '/batch');
-  for (var i = 0; i < addresses.length; i++) {
-    batch.query({ location: addresses[i] });
+module.exports.batch = function(key, addresses, callback) {
+  if (key != undefined) {
+    u = url + '/batch?key='+key;
+  } else {
+    u = url + '/batch';
   }
-  batch.end(function(err, res) {
-    if (err) {
-      callback(err);
-    } else {
-      var results = res.body.results.map(function(result) {
-        return result.locations[0];
-      });
-
-      callback(null, results);
-    }
-  });
-};
-
-module.exports.batchAuthenticated = function(key, addresses, callback) {
-  var batch = get(url + '/batch?key='+key);
+  var batch = get(u);
   for (var i = 0; i < addresses.length; i++) {
     batch.query({ location: addresses[i] });
   }

--- a/test/index.js
+++ b/test/index.js
@@ -8,43 +8,41 @@ describe('MqpQuest', function() {
 
   describe('#geocode()', function() {
     it('should get the proper lat/lon for an address', function(done) {
-      mapquest.geocode('1 Infinite Loop, Cupertino, CA 95014', function(err, res) {
-        res.latLng.lat.should.equal(37.33064);
-        res.latLng.lng.should.equal(-122.028983);
-        apple = res;
+      mapquest.geocode(undefined, '1 Infinite Loop, Cupertino, CA 95014', function(err, res) {
+        res[0].latLng.lat.should.equal(37.33064);
+        res[0].latLng.lng.should.equal(-122.028983);
+        apple = res[0];
         done(err);
       });
     });
 
     
     it('should return nothing for an empty address', function(done) {
-      mapquest.geocode('', function(err, res) {
-        should.not.exist(res);
+      mapquest.geocode(undefined, '', function(err, res) {
+        should.not.exist(res[0]);
         done(err);
       });
     });
 
     it('should return nothing for an invalid address', function(done) {
-      mapquest.geocode('She sells sea shells', function(err, res) {
-        should.not.exist(res);
+      mapquest.geocode(undefined, 'She sells sea shells', function(err, res) {
+        should.not.exist(res[0]);
         done(err);
       });
     });
-  });
-
-  describe('#gecodeAuthenticated()', function() {
     it('should take an optional api key', function(done) {
-      mapquest.geocodeAuthenticated('FAKEKEY', '1 Infinite Loop, Cupertino, CA 95014', function(err, res) {
-        should.not.exist(res);
+      mapquest.geocode('FAKEKEY', '1 Infinite Loop, Cupertino, CA 95014', function(err, res) {
+        should.not.exist(res[0]);
         done(err);
       });      
-    });
+    });    
   });
+
 
   describe('#reverse()', function() {
     it('should get the same address given for lat lng returned', function(done) {
-      mapquest.reverse({ latitude: apple.latLng.lat, longitude: apple.latLng.lng }, function(err, res) {
-        apple.latLng.should.eql(res.latLng);
+      mapquest.reverse(undefined, { latitude: apple.latLng.lat, longitude: apple.latLng.lng }, function(err, res) {
+        apple.latLng.should.eql(res[0].latLng);
         apple.street.should.equal('1 Infinite Loop');
         apple.postalCode.should.equal('95014');
         done(err);
@@ -52,39 +50,34 @@ describe('MqpQuest', function() {
     });
 
     it('should return nothing for empty coordinates', function(done) {
-      mapquest.reverse({}, function(err, res) {
-        should.not.exist(res);
+      mapquest.reverse(undefined, {}, function(err, res) {
+        should.not.exist(res[0]);
         done(err);
       });
     });
-  });
-
-  describe('#reverseAuthenticated()', function() {
     it('should take an API Key', function(done) {
-      mapquest.reverseAuthenticated('FAKEKEY', { latitude: apple.latLng.lat, longitude: apple.latLng.lng }, function(err, res) {
-        should.not.exist(res);
+      mapquest.reverse('FAKEKEY', { latitude: apple.latLng.lat, longitude: apple.latLng.lng }, function(err, res) {
+        should.not.exist(res[0]);
         done(err);
       });
-    });
+    });    
   });
 
   describe('#batch()', function() {
     it('should geocode multiple addresses at once', function(done) {
-      mapquest.batch([ '1 Infinite Loop, Cupertino, CA 95014', '1600 Amphitheatre Parkway, Mountain View, CA 94043' ], function(err, res) {
+      mapquest.batch(undefined, [ '1 Infinite Loop, Cupertino, CA 95014', '1600 Amphitheatre Parkway, Mountain View, CA 94043' ], function(err, res) {
         res.length.should.equal(2);
         res[0].street.should.equal('1 Infinite Loop');
         res[1].street.should.equal('1600 Amphitheatre Parkway');
         done(err);
       });
     });
-  });
-
-  describe('#batchAuthenticated()', function() {
     it('should take an API Key', function(done) {
-      mapquest.batchAuthenticated('FAKEKEY', [ '1 Infinite Loop, Cupertino, CA 95014', '1600 Amphitheatre Parkway, Mountain View, CA 94043' ], function(err, res) {
+      mapquest.batch('FAKEKEY', [ '1 Infinite Loop, Cupertino, CA 95014', '1600 Amphitheatre Parkway, Mountain View, CA 94043' ], function(err, res) {
         should.not.exist(res[0]);
         done(err);
       });
-    });
-  });  
+    });    
+  });
+
 });


### PR DESCRIPTION
I added a few functions that take an API key, to make the library compliant with the latest published docs - http://open.mapquestapi.com/geocoding/

I'm not wild about having the parallel functions, but it is fairly simple to use.  Other options if you'd like to minimize the duplication, and don't mind changing the function signatures:
1. Just keep the calls that require a key - this is mapquests documented behavior, and we have no guarantee of how long they'll support use without the key.
2. Change the function signatures to take an "options" object, rather than multiple arguments, for example, instead of 
   geocode('1 Infinite Loop', function(err, res) {})
   we would call
   geocode({address: '1 Infinite Loop', callback : function(err, res) {})

This would make it simpler to add optional parameters such as key.
